### PR TITLE
Release: track 0.9.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This module makes it easy to provision Palo Alto VM-Series Firewalls in Alkira.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.9.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.9.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.9.4 |
+| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.9.6 |
 
 ## Modules
 
@@ -23,8 +23,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [alkira_credential_pan.service](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/credential_pan) | resource |
-| [alkira_credential_pan_instance.instance](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/credential_pan_instance) | resource |
 | [alkira_service_pan.service](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/service_pan) | resource |
 | [alkira_segment.mgmt](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/data-sources/segment) | data source |
 | [alkira_segment.service](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/data-sources/segment) | data source |
@@ -35,11 +33,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bundle"></a> [bundle](#input\_bundle) | Software image bundle; required if using 'PAY\_AS\_YOU\_GO' license\_type | `string` | `"PAN_VM_300_BUNDLE_2"` | no |
-| <a name="input_credential"></a> [credential](#input\_credential) | Service credential values | <pre>object({<br>    name         = string<br>    username     = string<br>    password     = string<br>    license_key  = string<br>    license_type = string<br>  })</pre> | n/a | yes |
+| <a name="input_credential"></a> [credential](#input\_credential) | Service credential values | <pre>object({<br>    username         = optional(string)<br>    password         = optional(string)<br>    license_type     = optional(string)<br>    license_sub_type = optional(string)<br>  })</pre> | n/a | yes |
 | <a name="input_cxp"></a> [cxp](#input\_cxp) | Alkira CXP to provision service in | `string` | n/a | yes |
 | <a name="input_fw_type"></a> [fw\_type](#input\_fw\_type) | VM-Series type | `string` | `"VM-300"` | no |
 | <a name="input_fw_version"></a> [fw\_version](#input\_fw\_version) | VM-Series version | `string` | `"9.1.3"` | no |
-| <a name="input_instances"></a> [instances](#input\_instances) | Palo Alto instance configuration:<br>    - 'auth\_code' is required if using 'BRING\_YOUR\_OWN' license\_type<br>    - 'auth\_key' is required if Panorama is managing firewalls | <pre>list(object({<br>    name          = string<br>    username      = string<br>    password      = string<br>    license_key   = string<br>    auth_code     = optional(string)<br>    auth_key      = optional(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_instances"></a> [instances](#input\_instances) | Palo Alto instance configuration:<br>    - 'auth\_code' is required if using 'BRING\_YOUR\_OWN' license\_type<br>    - 'auth\_key' is required if Panorama is managing firewalls | <pre>list(object({<br>    name          = string<br>    license_key   = string<br>    auth_code     = optional(string)<br>    auth_key      = optional(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_master_key"></a> [master\_key](#input\_master\_key) | Every firewall and instance of Panorama has a 'master\_key' that encrypts all private keys and passwords.<br>  If auto-scale is configured, the 'master\_key' must match between Panorama and all managed firewalls. | <pre>object({<br>    enabled = optional(bool)<br>    value   = optional(string)<br>    expiry  = optional(string)<br>  })</pre> | `{}` | no |
 | <a name="input_max_instance_count"></a> [max\_instance\_count](#input\_max\_instance\_count) | Max number of Panorama instances for auto-scale; defaults to 1 if Panorama is not used | `number` | `1` | no |
 | <a name="input_mgmt_segment"></a> [mgmt\_segment](#input\_mgmt\_segment) | Management segment | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -58,11 +58,10 @@ variable "credential" {
   description    = "Service credential values"
 
   type = object({
-    name         = string
-    username     = string
-    password     = string
-    license_key  = string
-    license_type = string
+    username         = optional(string)
+    password         = optional(string)
+    license_type     = optional(string)
+    license_sub_type = optional(string)
   })
   sensitive  = true
 }
@@ -114,8 +113,6 @@ variable "instances" {
 
   type = list(object({
     name          = string
-    username      = string
-    password      = string
     license_key   = string
     auth_code     = optional(string)
     auth_key      = optional(string)

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,11 @@
 terraform {
-  required_version = ">= 0.14.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">= 1.3.0"
 
   required_providers {
 
     alkira = {
       source  = "alkiranet/alkira"
-      version = ">= 0.9.4"
+      version = ">= 0.9.6"
     }
 
   }


### PR DESCRIPTION
## Overview
The logic for **service** and **instance** credentials is now part of the service. [PAN Service Credential](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/credential_pan) and [PAN Instance Credential](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/credential_pan_instance) are now deprecated.